### PR TITLE
Update WoE (_cont_labels)

### DIFF
--- a/woe.py
+++ b/woe.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import cross_val_score
 __author__ = 'Denis Surzhko'
 
 
-# ver 0.2.2
+# ver 0.2.3
 # merge & _calc_stat bug fixes
 class WoE:
     """

--- a/woe.py
+++ b/woe.py
@@ -129,7 +129,7 @@ class WoE:
         if df is None:
             return None, None
         # Max buckets num calc
-        self.qnt_num = int(np.minimum(df['X'].unique().size / self._min_block_size, self.__qnt_num)) + 1
+        self.qnt_num = int(np.minimum(df['X'].size / self._min_block_size, self.__qnt_num)) + 1
         # cuts - label num for each observation, bins - quartile thresholds
         bins = None
         cuts = None


### PR DESCRIPTION
Using `.unique().` in `self.qnt_num` calculation leads to a smaller bucket number, especially in case of high `_min_block_size` and semi-discrete/semi-continuous values in `df['X']` like Age.